### PR TITLE
Update US_states_apps_map.html

### DIFF
--- a/adams/US_states_apps_map.html
+++ b/adams/US_states_apps_map.html
@@ -57,7 +57,7 @@
         
     
             var tile_layer_c3fbf045db841764fdc6ffe8a28f2773 = L.tileLayer(
-                "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
                 {"attribution": "Data by \u0026copy; \u003ca href=\"http://openstreetmap.org\"\u003eOpenStreetMap\u003c/a\u003e, under \u003ca href=\"http://www.openstreetmap.org/copyright\"\u003eODbL\u003c/a\u003e.", "detectRetina": false, "maxNativeZoom": 18, "maxZoom": 18, "minZoom": 0, "noWrap": false, "opacity": 1, "subdomains": "abc", "tms": false}
             ).addTo(map_16484ecb4d2b741f2292c1c3ef2600bb);
         


### PR DESCRIPTION
`{s}.` is no longer recommended now that we support HTTP/2 + HTTP/3.